### PR TITLE
Backport to >=1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # Check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.25
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.28
+loader_version=0.15.7
 
 # Mod Properties
 mod_version=2.0.0
@@ -14,4 +14,4 @@ maven_group=cc.unilock.zzz-rawr
 archives_base_name=zzz-rawr
 
 # Dependencies
-kaleido_version=0.1.1+1.1.0-beta.3
+kaleido_version=0.2.0+1.2.0-beta.5

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,6 @@
 	],
 	"depends": {
 		"fabricloader": "*",
-		"minecraft": ">=1.20"
+		"minecraft": ">=1.19.2"
 	}
 }


### PR DESCRIPTION
I tested the resulting jar on 1.20.1 and it worked fine, so this just changes the supported versions from >=1.20.1 to >=1.19.2